### PR TITLE
Use distroless image for smaller image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM golang:1-alpine
+FROM golang:1-alpine as build
 
-WORKDIR /usr/src/app
+WORKDIR /build
 
-COPY . .
+COPY go.mod go.sum /build/
 
-RUN go build -o /usr/bin/adguard-exporter && \
-    rm -rf /usr/src/app
+RUN go mod download
+
+COPY . /build
+
+RUN CGO_ENABLED=0 go build -o adguard-exporter .
+
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=build /build/adguard-exporter /usr/bin/adguard-exporter
 
 EXPOSE 9162
 


### PR DESCRIPTION
This pull request updates the Dockerfile to use the distroless image, resulting in a smaller image size. The image size is reduced from 100MB to 15MB.

Using a distroless image is also better for security, as it significantly reduces the attack service. 